### PR TITLE
Updated (But Non-Ideal) Evil URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/submodules/evil"]
 	path = vendor/submodules/evil
-	url = git://gitorious.org/evil/evil.git
+	url = https://github.com/emacsmirror/evil
 [submodule "vendor/submodules/evil-surround"]
 	path = vendor/submodules/evil-surround
 	url = https://github.com/timcharper/evil-surround.git


### PR DESCRIPTION
Since the gitorious website no longer hosts evilmode, the submodule URL must be switched. "https://github.com/emacsmirror/evil" is not the
official host of evil, so it is not the ideal solution, but there does
not appear to be an official host at the moment. This distribution of evil
mode has passed basic sanity checks of working for me.