### PR TITLE
updated evil submodule to my repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/submodules/evil"]
 	path = vendor/submodules/evil
-	url = https://github.com/emacsmirror/evil
+	url = https://github.com/dan-compton/evil.git
 [submodule "vendor/submodules/evil-surround"]
 	path = vendor/submodules/evil-surround
 	url = https://github.com/timcharper/evil-surround.git


### PR DESCRIPTION
Gitorious is dead and I suppose that emacsmirror cleared their repo because of this.  Consequently, you cannot update the evil submodule at this time.

I cloned the [mercurial repository](https://bitbucket.org/lyro/evil/wiki/Home), [created a new repository on github to house evil](https://bitbucket.org/lyro/evil/wiki/Home), and updated the evil submodule to reflect the URL and branch change.